### PR TITLE
Support for a precomputed SRP x

### DIFF
--- a/Sources/Client.swift
+++ b/Sources/Client.swift
@@ -12,7 +12,8 @@ public class Client {
     let algorithm: Digest.Algorithm
 
     let username: String
-    let password: String
+    var password: String? = nil
+    var precomputed_x: BigUInt? = nil
 
     var HAMK: Data? = nil
     var K: Data? = nil
@@ -23,7 +24,23 @@ public class Client {
     /// is also available.
     public private(set) var isAuthenticated = false
 
-    /// Initialize the Client SRP party.
+    private static func commonInit(
+        group: Group = .N2048,
+        privateKey: Data? = nil)
+        -> (BigUInt, BigUInt) {
+
+        var srp_a: BigUInt
+        if let privateKey = privateKey {
+            srp_a = BigUInt(privateKey)
+        } else {
+            srp_a = BigUInt(Data(bytes: try! Random.generate(byteCount: 128)))
+        }
+        // A = g^a % N
+        let srp_A = group.g.power(srp_a, modulus: group.N)
+        return (srp_a, srp_A)
+    }
+    
+    /// Initialize the Client SRP party with a password.
     ///
     /// - Parameters:
     ///   - username: user's username.
@@ -31,11 +48,11 @@ public class Client {
     ///   - group: which `Group` to use, must be the same for the
     ///       server as well as the pre-stored verificationKey.
     ///   - algorithm: which `Digest.Algorithm` to use, again this
-    ///       must be the same for the server as well as the pre-stored 
+    ///       must be the same for the server as well as the pre-stored
     ///       verificationKey.
-    ///   - privateKey: (optional) custom private key (a); if providing 
-    ///       the private key of the `Client`, make sure to provide a 
-    ///       good random key of at least 32 bytes. Default is to 
+    ///   - privateKey: (optional) custom private key (a); if providing
+    ///       the private key of the `Client`, make sure to provide a
+    ///       good random key of at least 32 bytes. Default is to
     ///       generate a private key of 128 bytes. You MUST not re-use
     ///       the private key between sessions.
     public init(
@@ -45,18 +62,40 @@ public class Client {
         algorithm: Digest.Algorithm = .sha1,
         privateKey: Data? = nil)
     {
-        self.group = group
-        self.algorithm = algorithm
         self.username = username
         self.password = password
-
-        if let privateKey = privateKey {
-            a = BigUInt(privateKey)
-        } else {
-            a = BigUInt(Data(bytes: try! Random.generate(byteCount: 128)))
-        }
-        // A = g^a % N
-        A = group.g.power(a, modulus: group.N)
+        self.group = group
+        self.algorithm = algorithm
+        (a, A) = Client.commonInit(group: group, privateKey: privateKey)
+    }
+    
+    /// Initialize the Client SRP party with a precomputed x.
+    ///
+    /// - Parameters:
+    ///   - username: user's username.
+    ///   - precomputed_x: precomputed SRP x.
+    ///   - group: which `Group` to use, must be the same for the
+    ///       server as well as the pre-stored verificationKey.
+    ///   - algorithm: which `Digest.Algorithm` to use, again this
+    ///       must be the same for the server as well as the pre-stored
+    ///       verificationKey.
+    ///   - privateKey: (optional) custom private key (a); if providing
+    ///       the private key of the `Client`, make sure to provide a
+    ///       good random key of at least 32 bytes. Default is to
+    ///       generate a private key of 128 bytes. You MUST not re-use
+    ///       the private key between sessions.
+    public init(
+        username: String,
+        precomputed_x: BigUInt,
+        group: Group = .N2048,
+        algorithm: Digest.Algorithm = .sha1,
+        privateKey: Data? = nil)
+    {
+        self.username = username
+        self.precomputed_x = precomputed_x
+        self.group = group
+        self.algorithm = algorithm
+        (a, A) = Client.commonInit(group: group, privateKey: privateKey)
     }
 
     /// Starts authentication. This method is a no-op.
@@ -89,7 +128,7 @@ public class Client {
 
         let u = calculate_u(group: group, algorithm: algorithm, A: publicKey, B: serverPublicKey)
         let k = calculate_k(group: group, algorithm: algorithm)
-        let x = calculate_x(algorithm: algorithm, salt: salt, username: username, password: password)
+        let x = self.precomputed_x ?? calculate_x(algorithm: algorithm, salt: salt, username: username, password: password!)
         let v = calculate_v(group: group, x: x)
 
         // shared secret

--- a/Sources/SRP.swift
+++ b/Sources/SRP.swift
@@ -29,6 +29,15 @@ public func createSaltedVerificationKey(
 {
     let salt = salt ?? Data(bytes: try! Random.generate(byteCount: 16))
     let x = calculate_x(algorithm: algorithm, salt: salt, username: username, password: password)
+    return createSaltedVerificationKey(from: x, group: group)
+}
+
+public func createSaltedVerificationKey(
+    from x: BigUInt,
+    salt: Data? = nil,
+    group: Group = .N2048)
+    -> (salt: Data, verificationKey: Data) {
+    let salt = salt ?? Data(bytes: try! Random.generate(byteCount: 16))
     let v = calculate_v(group: group, x: x)
     return (salt, v.serialize())
 }

--- a/Sources/SRP.swift
+++ b/Sources/SRP.swift
@@ -29,7 +29,7 @@ public func createSaltedVerificationKey(
 {
     let salt = salt ?? Data(bytes: try! Random.generate(byteCount: 16))
     let x = calculate_x(algorithm: algorithm, salt: salt, username: username, password: password)
-    return createSaltedVerificationKey(from: x, group: group)
+    return createSaltedVerificationKey(from: x, salt: salt, group: group)
 }
 
 public func createSaltedVerificationKey(

--- a/Sources/SRP.swift
+++ b/Sources/SRP.swift
@@ -32,11 +32,35 @@ public func createSaltedVerificationKey(
     return createSaltedVerificationKey(from: x, salt: salt, group: group)
 }
 
+/// Creates the salted verification key based on a precomputed SRP x value.
+/// Only the salt and verification key need to be stored on the
+/// server, there's no need to keep the plain-text password.
+///
+/// Keep the verification key private, as it can be used to brute-force
+/// the password from.
+///
+/// - Parameters:
+///   - x: precomputed SRP x
+///   - salt: (optional) custom salt value; if providing a salt, make sure to
+///       provide a good random salt of at least 16 bytes. Default is to
+///       generate a salt of 16 bytes.
+///   - group: `Group` parameters; default is 2048-bits group.
+/// - Returns: salt (s) and verification key (v)
 public func createSaltedVerificationKey(
+    from x: Data,
+    salt: Data? = nil,
+    group: Group = .N2048)
+    -> (salt: Data, verificationKey: Data)
+{
+    return createSaltedVerificationKey(from: BigUInt(x), salt: salt, group: group)
+}
+
+func createSaltedVerificationKey(
     from x: BigUInt,
     salt: Data? = nil,
     group: Group = .N2048)
-    -> (salt: Data, verificationKey: Data) {
+    -> (salt: Data, verificationKey: Data)
+{
     let salt = salt ?? Data(bytes: try! Random.generate(byteCount: 16))
     let v = calculate_v(group: group, x: x)
     return (salt, v.serialize())

--- a/Tests/SRPTests/ReadmeTests.swift
+++ b/Tests/SRPTests/ReadmeTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Cryptor
 import SRP
+import BigInt
 import XCTest
 
 class ReadmeTests: XCTestCase {
@@ -9,10 +10,27 @@ class ReadmeTests: XCTestCase {
         let userStore: [String: (salt: Data, verificationKey: Data)] = [
             "alice": createSaltedVerificationKey(username: "alice", password: "password123"),
             "bob": createSaltedVerificationKey(username: "bob", password: "qwerty12345"),
-        ]
-
+            ]
+        
         // Alice wants to authenticate, she sends her username to the server.
         let client = Client(username: "alice", password: "password123")
+        try runCommonTest(client: client, userStore: userStore)
+    }
+    
+    func testGivenSrpX() throws {
+        // This is a database of users, along with their salted verification keys
+        let userStore: [String: (salt: Data, verificationKey: Data)] = [
+            "alice": createSaltedVerificationKey(from: BigUInt(12345)),
+            "bob": createSaltedVerificationKey(from: BigUInt(67890)),
+            ]
+        
+        // Alice wants to authenticate, she sends her username to the server.
+        let client = Client(username: "alice", precomputed_x: BigUInt(12345))
+        try runCommonTest(client: client, userStore: userStore)
+    }
+    
+    func runCommonTest(client: Client, userStore: [String: (salt: Data, verificationKey: Data)]) throws {
+        // Alice wants to authenticate
         let (username, clientPublicKey) = client.startAuthentication()
 
         let server = Server(
@@ -45,6 +63,7 @@ class ReadmeTests: XCTestCase {
     static var allTests : [(String, (ReadmeTests) -> () throws -> Void)] {
         return [
             ("test", test),
+            ("testGivenSrpX", testGivenSrpX),
         ]
     }
 }

--- a/Tests/SRPTests/ReadmeTests.swift
+++ b/Tests/SRPTests/ReadmeTests.swift
@@ -10,22 +10,21 @@ class ReadmeTests: XCTestCase {
         let userStore: [String: (salt: Data, verificationKey: Data)] = [
             "alice": createSaltedVerificationKey(username: "alice", password: "password123"),
             "bob": createSaltedVerificationKey(username: "bob", password: "qwerty12345"),
-            ]
-        
+        ]
         // Alice wants to authenticate, she sends her username to the server.
         let client = Client(username: "alice", password: "password123")
         try runCommonTest(client: client, userStore: userStore)
     }
     
-    func testGivenSrpX() throws {
+    func testGivenSRPX() throws {
         // This is a database of users, along with their salted verification keys
         let userStore: [String: (salt: Data, verificationKey: Data)] = [
-            "alice": createSaltedVerificationKey(from: BigUInt(12345)),
-            "bob": createSaltedVerificationKey(from: BigUInt(67890)),
+            "alice": createSaltedVerificationKey(from: Data("12345".utf8)),
+            "bob": createSaltedVerificationKey(from: Data("67890".utf8)),
             ]
         
         // Alice wants to authenticate, she sends her username to the server.
-        let client = Client(username: "alice", precomputed_x: BigUInt(12345))
+        let client = Client(username: "alice", precomputedX: Data("12345".utf8))
         try runCommonTest(client: client, userStore: userStore)
     }
     
@@ -63,7 +62,7 @@ class ReadmeTests: XCTestCase {
     static var allTests : [(String, (ReadmeTests) -> () throws -> Void)] {
         return [
             ("test", test),
-            ("testGivenSrpX", testGivenSrpX),
+            ("testGivenSRPX", testGivenSRPX),
         ]
     }
 }

--- a/Tests/SRPTests/SRPTests.swift
+++ b/Tests/SRPTests/SRPTests.swift
@@ -14,12 +14,12 @@ class SRPTests: XCTestCase {
         runTest(group: .N8192, algorithm: .sha1, username: "alice", password: "password123")
         
         // test given precomputed SRP x
-        runGivenSrpXTest(group: .N1024, algorithm: .sha1, username: "alice")
-        runGivenSrpXTest(group: .N2048, algorithm: .sha1, username: "alice")
-        runGivenSrpXTest(group: .N3072, algorithm: .sha1, username: "alice")
-        runGivenSrpXTest(group: .N4096, algorithm: .sha1, username: "alice")
-        runGivenSrpXTest(group: .N6144, algorithm: .sha1, username: "alice")
-        runGivenSrpXTest(group: .N8192, algorithm: .sha1, username: "alice")
+        runGivenSRPXTest(group: .N1024, algorithm: .sha1, username: "alice")
+        runGivenSRPXTest(group: .N2048, algorithm: .sha1, username: "alice")
+        runGivenSRPXTest(group: .N3072, algorithm: .sha1, username: "alice")
+        runGivenSRPXTest(group: .N4096, algorithm: .sha1, username: "alice")
+        runGivenSRPXTest(group: .N6144, algorithm: .sha1, username: "alice")
+        runGivenSRPXTest(group: .N8192, algorithm: .sha1, username: "alice")
     }
 
     func testSHA256() {
@@ -31,12 +31,12 @@ class SRPTests: XCTestCase {
         runTest(group: .N8192, algorithm: .sha256, username: "alice", password: "password123")
         
         // test given precomputed SRP x
-        runGivenSrpXTest(group: .N1024, algorithm: .sha256, username: "alice")
-        runGivenSrpXTest(group: .N2048, algorithm: .sha256, username: "alice")
-        runGivenSrpXTest(group: .N3072, algorithm: .sha256, username: "alice")
-        runGivenSrpXTest(group: .N4096, algorithm: .sha256, username: "alice")
-        runGivenSrpXTest(group: .N6144, algorithm: .sha256, username: "alice")
-        runGivenSrpXTest(group: .N8192, algorithm: .sha256, username: "alice")
+        runGivenSRPXTest(group: .N1024, algorithm: .sha256, username: "alice")
+        runGivenSRPXTest(group: .N2048, algorithm: .sha256, username: "alice")
+        runGivenSRPXTest(group: .N3072, algorithm: .sha256, username: "alice")
+        runGivenSRPXTest(group: .N4096, algorithm: .sha256, username: "alice")
+        runGivenSRPXTest(group: .N6144, algorithm: .sha256, username: "alice")
+        runGivenSRPXTest(group: .N8192, algorithm: .sha256, username: "alice")
     }
 
     func testCustomGroupParameters() {
@@ -45,8 +45,8 @@ class SRPTests: XCTestCase {
         runTest(group: group, algorithm: .sha256, username: "alice", password: "password123")
         
         // test given precomputed SRP x
-        runGivenSrpXTest(group: group, algorithm: .sha1, username: "alice")
-        runGivenSrpXTest(group: group, algorithm: .sha256, username: "alice")
+        runGivenSRPXTest(group: group, algorithm: .sha1, username: "alice")
+        runGivenSRPXTest(group: group, algorithm: .sha256, username: "alice")
     }
 
     func testUtf8() {
@@ -54,7 +54,7 @@ class SRPTests: XCTestCase {
         runTest(group: .N1024, algorithm: .sha1, username: "bõūkę", password: "😅")
         
         // test given precomputed SRP x
-        runGivenSrpXTest(group: .N1024, algorithm: .sha1, username: "bõūkę")
+        runGivenSRPXTest(group: .N1024, algorithm: .sha1, username: "bõūkę")
     }
 
     func runTest(
@@ -71,13 +71,13 @@ class SRPTests: XCTestCase {
          * authentication process.
          */
         let (salt, verificationKey) = createSaltedVerificationKey(username: username, password: password, group: group, algorithm: algorithm)
-        
+
         // Begin authentication process
         let client = Client(username: username, password: password, group: group, algorithm: algorithm)
         runCommonTest(group: group, algorithm: algorithm, username: username, salt: salt, verificationKey: verificationKey, client: client)
     }
     
-    func runGivenSrpXTest(
+    func runGivenSRPXTest(
         group: Group,
         algorithm: Digest.Algorithm,
         username: String,
@@ -88,11 +88,11 @@ class SRPTests: XCTestCase {
          * key must be stored by the server-side application for use during the
          * authentication process.
          */
-        let precomputed_x = BigUInt(12345)
-        let (salt, verificationKey) = createSaltedVerificationKey(from: precomputed_x, group: group)
+        let precomputedX: Data = Data("12345".utf8)
+        let (salt, verificationKey) = createSaltedVerificationKey(from: precomputedX, group: group)
         
         // Begin authentication process
-        let client = Client(username: username, precomputed_x: precomputed_x, group: group, algorithm: algorithm)
+        let client = Client(username: username, precomputedX: precomputedX, group: group, algorithm: algorithm)
         runCommonTest(group: group, algorithm: algorithm, username: username, salt: salt, verificationKey: verificationKey, client: client)
     }
     
@@ -173,10 +173,10 @@ class SRPTests: XCTestCase {
             XCTFail("Incorrect error thrown: \(error)")
         }
     }
-    
-    func testClientGivenSrpXAborts() {
-        let precomputed_x = BigUInt(12345)
-        let client = Client(username: "alice", precomputed_x: precomputed_x)
+
+    func testClientGivenSRPXAborts() {
+        let precomputedX = Data("12345".utf8)
+        let client = Client(username: "alice", precomputedX: precomputedX)
         do {
             _ = try client.processChallenge(
                 salt: try! Data(hex: String(repeating: "0", count: 16)),
@@ -204,8 +204,8 @@ class SRPTests: XCTestCase {
         }
     }
     
-    func testServerGivenSrpXAborts() {
-        let (salt, verificationKey) = createSaltedVerificationKey(from: BigUInt(12345))
+    func testServerGivenSRPXAborts() {
+        let (salt, verificationKey) = createSaltedVerificationKey(from: Data("12345".utf8))
         let server = Server(username: "alice", salt: salt, verificationKey: verificationKey)
         do {
             _ = try server.verifySession(
@@ -226,9 +226,9 @@ class SRPTests: XCTestCase {
             ("testCustomGroupParameters", testCustomGroupParameters),
             ("testUtf8", testUtf8),
             ("testClientAborts", testClientAborts),
-            ("testClientGivenSrpXAborts", testClientGivenSrpXAborts),
-            ("testServerAborts", testServerGivenSrpXAborts),
-            ("testServerGivenSrpXAborts", testServerGivenSrpXAborts),
+            ("testClientGivenSRPXAborts", testClientGivenSRPXAborts),
+            ("testServerAborts", testServerGivenSRPXAborts),
+            ("testServerGivenSRPXAborts", testServerGivenSRPXAborts),
         ]
     }
 }


### PR DESCRIPTION
Related Issue: https://github.com/Bouke/SRP/issues/7

Exposed alternate init / function for providing a precomputed SRP x instead of having the library compute an x from a user-provided username and password.

Updated the readme tests and the SRP tests.

Please note: I have not yet updated the pysrptools test as this requires some more modifications in the remotepy script for constructing the remote client/server. 